### PR TITLE
Fix `ClassNotFoundException` when the app is minified

### DIFF
--- a/Packages/MobileSupportStorage/CHANGELOG.md
+++ b/Packages/MobileSupportStorage/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - Bug Fixes :bug:
   - Android: downgraded library's `compileSdkVersion` to 35 to reduce unnecessary SDK upgrades
+  - Android: fixed `ClassNotFoundException` when the app is minified
 
 ## v1.0.1 - 2025/10/14
 

--- a/Packages/MobileSupportStorage/Runtime/Plugins/Android/MobileSupportStorage.androidlib/build.gradle
+++ b/Packages/MobileSupportStorage/Runtime/Plugins/Android/MobileSupportStorage.androidlib/build.gradle
@@ -7,6 +7,7 @@ android {
 
     defaultConfig {
         minSdkVersion 19
+        consumerProguardFiles 'proguard-rules.pro'
     }
 
     buildTypes {

--- a/Packages/MobileSupportStorage/Runtime/Plugins/Android/MobileSupportStorage.androidlib/proguard-rules.pro
+++ b/Packages/MobileSupportStorage/Runtime/Plugins/Android/MobileSupportStorage.androidlib/proguard-rules.pro
@@ -20,4 +20,4 @@
 # hide the original source file name.
 #-renamesourcefileattribute SourceFile
 
--keep class jp.co.cyberagent.unitysupport.* { public *; }
+-keep class jp.co.cyberagent.unitysupport.storage.* { public *; }

--- a/Packages/MobileSupportThermal/CHANGELOG.md
+++ b/Packages/MobileSupportThermal/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - Bug Fixes :bug:
   - Android: downgraded library's `compileSdkVersion` to 35 to reduce unnecessary SDK upgrades
+  - Android: fixed `ClassNotFoundException` when the app is minified
 
 ## v2.0.1 - 2025/10/14
 

--- a/Packages/MobileSupportThermal/Runtime/Plugins/Android/MobileSupportThermal.androidlib/build.gradle
+++ b/Packages/MobileSupportThermal/Runtime/Plugins/Android/MobileSupportThermal.androidlib/build.gradle
@@ -7,6 +7,7 @@ android {
 
     defaultConfig {
         minSdkVersion 19
+        consumerProguardFiles 'proguard-rules.pro'
     }
 
     buildTypes {

--- a/Packages/MobileSupportThermal/Runtime/Plugins/Android/MobileSupportThermal.androidlib/proguard-rules.pro
+++ b/Packages/MobileSupportThermal/Runtime/Plugins/Android/MobileSupportThermal.androidlib/proguard-rules.pro
@@ -20,4 +20,4 @@
 # hide the original source file name.
 #-renamesourcefileattribute SourceFile
 
--keep class jp.co.cyberagent.unitysupport.* { public *; }
+-keep class jp.co.cyberagent.unitysupport.thermal.* { public *; }


### PR DESCRIPTION
- Fixed classes from `androidlib` is removed due to lack of `consumerProguardFile` in `build.gradle` and wrong proguard rules when the app is minified, causing `ClassNotFoundException`.
  - See: https://developer.android.com/topic/performance/app-optimization/library-optimization